### PR TITLE
refactor: general code cleanup and docs

### DIFF
--- a/kernel/src/sdk/display.rs
+++ b/kernel/src/sdk/display.rs
@@ -53,11 +53,20 @@ pub fn vexImagePngRead(
 ) -> u32 {
     Default::default()
 }
-pub fn vexDisplayVPrintf(xpos: i32, ypos: i32, bOpaque: i32, format: *const c_char, args: VaList) {}
-pub fn vexDisplayVString(nLineNumber: i32, format: *const c_char, args: VaList) {}
-pub fn vexDisplayVStringAt(xpos: i32, ypos: i32, format: *const c_char, args: VaList) {}
-pub fn vexDisplayVBigString(nLineNumber: i32, format: *const c_char, args: VaList) {}
-pub fn vexDisplayVBigStringAt(xpos: i32, ypos: i32, format: *const c_char, args: VaList) {}
-pub fn vexDisplayVSmallStringAt(xpos: i32, ypos: i32, format: *const c_char, args: VaList) {}
-pub fn vexDisplayVCenteredString(nLineNumber: i32, format: *const c_char, args: VaList) {}
-pub fn vexDisplayVBigCenteredString(nLineNumber: i32, format: *const c_char, args: VaList) {}
+pub fn vexDisplayVPrintf(
+    xpos: i32,
+    ypos: i32,
+    bOpaque: i32,
+    format: *const c_char,
+    args: VaList<'_, '_>,
+) {
+}
+pub fn vexDisplayVString(nLineNumber: i32, format: *const c_char, args: VaList<'_, '_>) {}
+pub fn vexDisplayVStringAt(xpos: i32, ypos: i32, format: *const c_char, args: VaList<'_, '_>) {}
+pub fn vexDisplayVBigString(nLineNumber: i32, format: *const c_char, args: VaList<'_, '_>) {}
+pub fn vexDisplayVBigStringAt(xpos: i32, ypos: i32, format: *const c_char, args: VaList<'_, '_>) {}
+pub fn vexDisplayVSmallStringAt(xpos: i32, ypos: i32, format: *const c_char, args: VaList<'_, '_>) {
+}
+pub fn vexDisplayVCenteredString(nLineNumber: i32, format: *const c_char, args: VaList<'_, '_>) {}
+pub fn vexDisplayVBigCenteredString(nLineNumber: i32, format: *const c_char, args: VaList<'_, '_>) {
+}

--- a/kernel/src/sdk/mod.rs
+++ b/kernel/src/sdk/mod.rs
@@ -4,6 +4,7 @@
     non_camel_case_types,
     non_upper_case_globals,
     non_snake_case,
+    clippy::too_many_arguments,
     clippy::missing_const_for_fn
 )]
 

--- a/kernel/src/sdk/serial.rs
+++ b/kernel/src/sdk/serial.rs
@@ -8,7 +8,7 @@ use core::{
 use crate::Mutex;
 use heapless::spsc::Queue;
 use semihosting::io::{stdout, Write};
-use snafu::{OptionExt, ResultExt, Snafu};
+use snafu::{OptionExt, Snafu};
 use vexide_core::{
     io::{Cursor, Stdin},
     sync::LazyLock,

--- a/kernel/src/xil/mod.rs
+++ b/kernel/src/xil/mod.rs
@@ -6,7 +6,8 @@
     unused_variables,
     non_camel_case_types,
     non_upper_case_globals,
-    non_snake_case
+    non_snake_case,
+    clippy::missing_safety_doc
 )]
 
 pub mod exception;

--- a/kernel/src/xil/wdt.rs
+++ b/kernel/src/xil/wdt.rs
@@ -17,9 +17,6 @@ pub const XSCUWDT_DISABLE_VALUE_2: u32 = 0x87654321;
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct XScuWdt_Config {
     pub Name: *const c_char,
-    // NOTE: libxil for some reason marks this as UINTPTR, but its not
-    // treated as such, and marking this as *mut c_uint here causes trouble
-    // on the rust end of things, so we'll just treat it as u32.
     pub BaseAddr: u32,
     pub IntrId: u32,
     pub IntrParent: *mut c_uint,
@@ -46,7 +43,7 @@ extern "C" {
 pub unsafe extern "C" fn XScuWdt_GetControlReg(InstancePtr: *const XScuWdt) -> u32 {
     unsafe {
         core::ptr::read_volatile(
-            ((*InstancePtr).Config.BaseAddr as u32 + XSCUWDT_CONTROL_OFFSET) as *const u32,
+            ((*InstancePtr).Config.BaseAddr + XSCUWDT_CONTROL_OFFSET) as *const u32,
         )
     }
 }
@@ -54,7 +51,7 @@ pub unsafe extern "C" fn XScuWdt_GetControlReg(InstancePtr: *const XScuWdt) -> u
 pub unsafe extern "C" fn XScuWdt_SetControlReg(InstancePtr: *mut XScuWdt, ControlReg: u32) {
     unsafe {
         core::ptr::write_volatile(
-            ((*InstancePtr).Config.BaseAddr as u32 + XSCUWDT_CONTROL_OFFSET) as *mut u32,
+            ((*InstancePtr).Config.BaseAddr + XSCUWDT_CONTROL_OFFSET) as *mut u32,
             ControlReg,
         );
     }
@@ -63,7 +60,7 @@ pub unsafe extern "C" fn XScuWdt_SetControlReg(InstancePtr: *mut XScuWdt, Contro
 pub unsafe extern "C" fn XScuWdt_LoadWdt(InstancePtr: *mut XScuWdt, Value: u32) {
     unsafe {
         core::ptr::write_volatile(
-            ((*InstancePtr).Config.BaseAddr as u32 + XSCUWDT_LOAD_OFFSET) as *mut u32,
+            ((*InstancePtr).Config.BaseAddr + XSCUWDT_LOAD_OFFSET) as *mut u32,
             Value,
         );
     }
@@ -72,11 +69,11 @@ pub unsafe extern "C" fn XScuWdt_LoadWdt(InstancePtr: *mut XScuWdt, Value: u32) 
 pub unsafe extern "C" fn XScuWdt_SetTimerMode(InstancePtr: *mut XScuWdt) {
     unsafe {
         core::ptr::write_volatile(
-            ((*InstancePtr).Config.BaseAddr as u32 + XSCUWDT_DISABLE_OFFSET) as *mut u32,
+            ((*InstancePtr).Config.BaseAddr + XSCUWDT_DISABLE_OFFSET) as *mut u32,
             XSCUWDT_DISABLE_VALUE_1,
         );
         core::ptr::write_volatile(
-            ((*InstancePtr).Config.BaseAddr as u32 + XSCUWDT_DISABLE_OFFSET) as *mut u32,
+            ((*InstancePtr).Config.BaseAddr + XSCUWDT_DISABLE_OFFSET) as *mut u32,
             XSCUWDT_DISABLE_VALUE_2,
         );
     }


### PR DESCRIPTION
- Resolves all compiler warnings in the kernel.
- Adds comments to a lot of functions missing them.
- Reworks a small detail on how timer_interrupt_handler actually gets the timer peripheral (using the intended way).