### PR TITLE
feat: usb1 serial buffering, fix clients, update nightly

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 	"features": {
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/devcontainers/features/rust:1": {
-			"version": "nightly-2024-06-20",
+			"version": "nightly-2025-02-18",
 			"profile": "default",
 			"targets": "armv7a-none-eabi"
 		},

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "clap-num"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e063d263364859dc54fb064cedb7c122740cd4733644b14b176c097f51e8ab7"
+checksum = "822c4000301ac390e65995c62207501e3ef800a1fc441df913a5e8e4dc374816"
 dependencies = [
  "num-traits",
 ]
@@ -1061,16 +1061,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cstr_core"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd98742e4fdca832d40cab219dc2e3048de17d873248f83f17df47c1bea70956"
-dependencies = [
- "cty",
- "memchr",
-]
-
-[[package]]
 name = "ctor"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,12 +1069,6 @@ dependencies = [
  "quote",
  "syn 2.0.76",
 ]
-
-[[package]]
-name = "cty"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "darling"
@@ -1252,12 +1236,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
-name = "either"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
 name = "embed-resource"
 version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,6 +1260,15 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "embedded-io-extras"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2f31813223d8ced7a76dcd83823400f0c40c0390439fa6467f6edcd67b2a036"
+dependencies = [
+ "embedded-io",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1413,13 +1400,15 @@ dependencies = [
 
 [[package]]
 name = "fimg"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190af4559b118e547e8d454948e73121a88e0f1884169734374e52effb93742c"
+checksum = "6739c38489a0264e04537f68b822f4cb7abb732b41eca5229a91685fcc998939"
 dependencies = [
  "atools",
  "clipline",
+ "hinted",
  "libc",
+ "lower",
  "mattr",
  "png",
  "umath",
@@ -1960,6 +1949,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hinted"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c488b6122f67ca2749a801d562c8c952e1778c42910c43ef537a6f5a46b524f2"
+
+[[package]]
 name = "html5ever"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2201,15 +2196,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,10 +2291,11 @@ dependencies = [
  "bincode",
  "critical-section",
  "embedded-io",
+ "embedded-io-extras",
  "heapless",
  "lock_api",
  "log",
- "printf-compat",
+ "ringbuffer",
  "snafu",
  "talc",
  "vex-sdk",
@@ -2433,6 +2420,26 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "lower"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913cca45d9edb04b7ce3334ad0e551e29b2e8f3eea7f0c9c1f799dc2f33bc80e"
+dependencies = [
+ "lower-macros",
+]
+
+[[package]]
+name = "lower-macros"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1fe6a5008813f4afca3ab15d0485fc3ea47d572e7128e325a22057cb863b11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3220,18 +3227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "printf-compat"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b002af28ffe3d3d67202ae717810a28125a494d5396debc43de01ee136ac404"
-dependencies = [
- "bitflags 1.3.2",
- "cstr_core",
- "cty",
- "itertools",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3554,6 +3549,12 @@ dependencies = [
  "web-sys",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "ringbuffer"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b0b88a509053cbfd535726dcaaceee631313cef981266119527a1d110f6d2b"
 
 [[package]]
 name = "rkyv"
@@ -5148,7 +5149,6 @@ dependencies = [
  "miette",
  "thiserror",
  "tokio",
- "vex-v5-display-simulator",
  "vex-v5-qemu-protocol",
 ]
 

--- a/packages/client-cli/Cargo.toml
+++ b/packages/client-cli/Cargo.toml
@@ -17,10 +17,10 @@ workspace = true
 tokio = { version = "1.23.0", features = ["full"] }
 miette = { version = "7.2.0", features = ["fancy"] }
 clap = { version = "4.5.1", features = ["derive", "env"] }
+clap-num = "1.2.0"
 anyhow = "1.0.86"
 bincode = "2.0.0-rc.3"
 vex-v5-qemu-host = { path = "../host" }
 thiserror = "1.0.63"
 log = "0.4.22"
 simplelog = "0.12.2"
-clap-num = "1.1.1"

--- a/packages/client-cli/src/main.rs
+++ b/packages/client-cli/src/main.rs
@@ -1,19 +1,24 @@
-use std::{option::Option, ffi::OsStr, fs::File, io::Read, num::NonZeroU32, path::{Path, PathBuf}};
+use std::{option::Option, path::PathBuf};
 
-use anyhow::{bail, Context};
-use clap_num::maybe_hex;
+use anyhow::Context;
 use log::LevelFilter;
 use simplelog::{ColorChoice, ConfigBuilder, TermLogger, TerminalMode};
 use tokio::{
-    io::{stdout, AsyncReadExt, AsyncWriteExt, BufReader},
+    io::{stdout, AsyncReadExt, AsyncWriteExt},
     process::Command,
 };
-use vex_v5_qemu_host::brain::{Brain, Program};
+use vex_v5_qemu_host::brain::{Binary, Brain};
 
-// TODO: fix this cursedness
+#[cfg(debug_assertions)]
 const DEFAULT_KERNEL: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../../target/armv7a-none-eabi/debug/kernel"
+);
+
+#[cfg(not(debug_assertions))]
+const DEFAULT_KERNEL: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../target/armv7a-none-eabi/release/kernel"
 );
 
 /// Simulate a VEX V5 robot program
@@ -24,7 +29,7 @@ struct Opt {
     /// When enabled, the simulator will make a GDB server available on port
     /// 1234, allowing a debugger to set breakpoints in and step through the
     /// kernel or user code.
-    #[clap(short, long, global = true, env = "V5_SIM_GDB")]
+    #[clap(short, long, env = "V5_SIM_GDB")]
     gdb: bool,
 
     /// Override the kernel image.
@@ -33,47 +38,31 @@ struct Opt {
     /// and set up the virtual machine before running the robot code.
     /// This option defaults to a kernel designed to replicate the behavior
     /// of programs under VEXos.
-    #[clap(short, long, global = true, default_value = DEFAULT_KERNEL, env = "V5_SIM_KERNEL_PATH")]
+    #[clap(short, long, default_value = DEFAULT_KERNEL, env = "V5_SIM_KERNEL_PATH")]
     kernel: PathBuf,
 
     /// Override the QEMU executable to a custom version of `qemu-system-arm`.
-    #[clap(short, long, global = true, default_value = "qemu-system-arm", env = "V5_SIM_QEMU")]
+    #[clap(short, long, default_value = "qemu-system-arm", env = "V5_SIM_QEMU")]
     qemu: PathBuf,
 
-    /// What type of program to simulate
-    #[clap(subcommand)]
-    program_type: Subcommands,
+    /// Main program binary
+    #[clap(long)]
+    program: PathBuf,
+
+    /// Main program binary load address
+    #[clap(long)]
+    load_addr: Option<u32>,
+
+    /// Linked program binary
+    #[clap(long, requires("link_addr"))]
+    link: Option<PathBuf>,
+
+    /// Linked program binary load address
+    #[clap(long, value_parser = validate_address_range)]
+    link_addr: Option<u32>,
 
     /// Extra arguments to pass to QEMU.
     qemu_args: Vec<String>,
-}
-
-#[derive(clap::Subcommand)]
-enum Subcommands {
-    /// Simulate a monolith binary at <BIN>
-    Monolith {
-        /// The binary to run
-        #[clap(env = "V5_SIM_BINARY_PATH")]
-        bin: PathBuf,
-    },
-    /// Simulate a hot/cold binary at <HOT_BIN> and <COLD_BIN>
-    HotCold {
-        /// The hot binary to run
-        #[clap(env = "V5_SIM_HOT_BINARY_PATH")]
-        hot_bin: PathBuf,
-
-        /// The cold binary to run
-        #[clap(env = "V5_SIM_COLD_BINARY_PATH")]
-        cold_bin: PathBuf,
-
-        /// Override the address to load the hot binary at
-        #[clap(long, global = true, default_value = "0x07800000", value_parser=maybe_hex::<u32>, env = "V5_SIM_HOT_ADDR")]
-        hot_addr: u32,
-
-        /// Override the address to load the cold binary at
-        #[clap(long, global = true, default_value = "0x03800000", value_parser=maybe_hex::<u32>, env = "V5_SIM_COLD_ADDR")]
-        cold_addr: u32,
-    }
 }
 
 #[tokio::main]
@@ -98,28 +87,21 @@ async fn main() -> anyhow::Result<()> {
         qemu.args(["-S", "-s"]);
     }
 
-    match opt.program_type {
-        Subcommands::Monolith {bin} => {
-            brain
-                .run_program(qemu, opt.kernel, Program{path: bin, load_addr: NonZeroU32::new(0x03800000).unwrap()}, None)
-                .await
-                .context("Failed to start QEMU.")?;
-        }
-        Subcommands::HotCold {hot_bin, cold_bin, hot_addr, cold_addr} => {
-            if hot_addr == 0 {
-                bail!("Hot load address cannot be zero!");
-            }
-            if cold_addr == 0 {
-                bail!("Cold load address cannot be zero!");
-            }
-            let hot_addr = NonZeroU32::new(hot_addr).unwrap();
-            let cold_addr = NonZeroU32::new(cold_addr).unwrap();
-            brain
-                .run_program(qemu, opt.kernel, Program{path: hot_bin, load_addr: hot_addr}, Some(Program{path: cold_bin, load_addr: cold_addr}))
-                .await
-                .context("Failed to start QEMU.")?;
-        }
-    }
+    brain
+        .run_program(
+            qemu,
+            opt.kernel,
+            Binary {
+                path: opt.program,
+                load_addr: opt.load_addr.unwrap_or(0x03800000),
+            },
+            opt.link.map(|link| Binary {
+                path: link,
+                load_addr: opt.link_addr.unwrap(),
+            }),
+        )
+        .await
+        .context("Failed to start QEMU.")?;
 
     // brain.kill_program().await.unwrap();
 
@@ -143,4 +125,8 @@ async fn main() -> anyhow::Result<()> {
     usb_task.abort();
 
     Ok(())
+}
+
+fn validate_address_range(s: &str) -> Result<u32, String> {
+    clap_num::maybe_hex_range(s, 0x03800000, 0x8000000)
 }

--- a/packages/client/src-tauri/src/qemu.rs
+++ b/packages/client/src-tauri/src/qemu.rs
@@ -2,10 +2,8 @@ use std::{borrow::BorrowMut, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 use tauri::State;
-use tokio::{
-    process::Command,
-    sync::Mutex,
-};
+use tokio::{process::Command, sync::Mutex};
+use vex_v5_qemu_host::brain::Binary;
 
 use crate::AppState;
 
@@ -42,7 +40,15 @@ pub async fn spawn_qemu(
     cmd.borrow_mut().args(opts.qemu_args);
 
     brain
-        .run_program(cmd, opts.kernel, opts.binary)
+        .run_program(
+            cmd,
+            opts.kernel,
+            Binary {
+                path: opts.binary,
+                load_addr: 0x03800000,
+            },
+            None,
+        )
         .await
         .map_err(|_| "Failed to start QEMU process.")?;
 

--- a/packages/display/Cargo.toml
+++ b/packages/display/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 ab_glyph = "0.2.28"
-fimg = { version = "0.4.43", features = ["save"], default-features = false }
+fimg = { version = "0.4.45", features = ["save"], default-features = false }
 image = { version = "0.25.2", default-features = false }
 vex-v5-qemu-protocol = { version = "0.0.1", path = "../protocol" }
 

--- a/packages/host/Cargo.toml
+++ b/packages/host/Cargo.toml
@@ -21,5 +21,5 @@ bincode = "2.0.0-rc.3"
 cobs = "0.2.3"
 log = "0.4.22"
 image = { version = "0.25.2", default-features = false }
-vex-v5-display-simulator = { version = "0.1.0", path = "../display" }
+# vex-v5-display-simulator = { version = "0.1.0", path = "../display" }
 bytemuck = "1.17.0"

--- a/packages/host/src/peripherals/display.rs
+++ b/packages/host/src/peripherals/display.rs
@@ -11,13 +11,12 @@ use tokio::{
     },
     task::AbortHandle,
 };
-use vex_v5_display_simulator::{
-    DisplayRenderer, Pack, TextLine, TextOptions, DEFAULT_BACKGROUND, DEFAULT_FOREGROUND,
-    DISPLAY_HEIGHT, DISPLAY_WIDTH,
-};
+// use vex_v5_display_simulator::{
+//     DisplayRenderer, Pack, TextLine, TextOptions, DEFAULT_BACKGROUND, DEFAULT_FOREGROUND,
+// };
 use vex_v5_qemu_protocol::{
     display::{DrawCommand, TextLocation},
-    DisplayCommand, KernelBoundPacket, SmartPortCommand, SmartPortData,
+    DisplayCommand, KernelBoundPacket,
 };
 
 #[derive(Debug)]
@@ -31,86 +30,86 @@ impl Display {
         let (data_tx, data_rx) = watch::channel(Mutex::new(None));
         Self {
             task: tokio::spawn(async move {
-                let mut renderer = DisplayRenderer::new(DEFAULT_FOREGROUND, DEFAULT_BACKGROUND);
+            //     let mut renderer = DisplayRenderer::new(DEFAULT_FOREGROUND, DEFAULT_BACKGROUND);
 
-                while let Some(command) = rx.recv().await {
-                    let mut new_frame = None;
-                    match command {
-                        DisplayCommand::Draw {
-                            command,
-                            color,
-                            clip_region: _,
-                        } => {
-                            renderer.foreground_color = Pack::unpack(color.0);
-                            match command {
-                                DrawCommand::Fill(shape) => {
-                                    renderer.draw(shape, false);
-                                }
-                                DrawCommand::Stroke(shape) => {
-                                    renderer.draw(shape, true);
-                                }
-                                DrawCommand::Text {
-                                    data,
-                                    size,
-                                    location,
-                                    opaque,
-                                    background,
-                                } => {
-                                    renderer.background_color = Pack::unpack(background.0);
-                                    let coords = match location {
-                                        TextLocation::Coordinates(coords) => coords,
-                                        TextLocation::Line(line) => TextLine(line).coords(),
-                                    };
+            //     while let Some(command) = rx.recv().await {
+            //         let mut new_frame = None;
+            //         match command {
+            //             DisplayCommand::Draw {
+            //                 command,
+            //                 color,
+            //                 clip_region: _,
+            //             } => {
+            //                 renderer.foreground_color = Pack::unpack(color.0);
+            //                 match command {
+            //                     DrawCommand::Fill(shape) => {
+            //                         renderer.draw(shape, false);
+            //                     }
+            //                     DrawCommand::Stroke(shape) => {
+            //                         renderer.draw(shape, true);
+            //                     }
+            //                     DrawCommand::Text {
+            //                         data,
+            //                         size,
+            //                         location,
+            //                         opaque,
+            //                         background,
+            //                     } => {
+            //                         renderer.background_color = Pack::unpack(background.0);
+            //                         let coords = match location {
+            //                             TextLocation::Coordinates(coords) => coords,
+            //                             TextLocation::Line(line) => TextLine(line).coords(),
+            //                         };
 
-                                    renderer.write_text(
-                                        data,
-                                        coords,
-                                        !opaque,
-                                        TextOptions { size: size.into() },
-                                    );
-                                }
-                                DrawCommand::CopyBuffer {
-                                    top_left,
-                                    bottom_right,
-                                    stride,
-                                    buffer,
-                                } => {
-                                    let buffer = bytemuck::cast_slice(&buffer);
-                                    renderer.draw_buffer(
-                                        buffer,
-                                        top_left,
-                                        bottom_right,
-                                        stride.get().into(),
-                                    );
-                                }
-                            }
-                        }
-                        DisplayCommand::Erase {
-                            color,
-                            clip_region: _,
-                        } => {
-                            renderer.foreground_color = Pack::unpack(color.0);
-                            renderer.erase();
-                        }
-                        DisplayCommand::Render => {
-                            new_frame = renderer.render(true);
-                        }
-                        DisplayCommand::DisableDoubleBuffering => {
-                            renderer.disable_double_buffer();
-                        }
-                        DisplayCommand::Scroll { .. } => {
-                            todo!()
-                        }
-                    }
+            //                         renderer.write_text(
+            //                             data,
+            //                             coords,
+            //                             !opaque,
+            //                             TextOptions { size: size.into() },
+            //                         );
+            //                     }
+            //                     DrawCommand::CopyBuffer {
+            //                         top_left,
+            //                         bottom_right,
+            //                         stride,
+            //                         buffer,
+            //                     } => {
+            //                         let buffer = bytemuck::cast_slice(&buffer);
+            //                         renderer.draw_buffer(
+            //                             buffer,
+            //                             top_left,
+            //                             bottom_right,
+            //                             stride.get().into(),
+            //                         );
+            //                     }
+            //                 }
+            //             }
+            //             DisplayCommand::Erase {
+            //                 color,
+            //                 clip_region: _,
+            //             } => {
+            //                 renderer.foreground_color = Pack::unpack(color.0);
+            //                 renderer.erase();
+            //             }
+            //             DisplayCommand::Render => {
+            //                 new_frame = renderer.render(true);
+            //             }
+            //             DisplayCommand::DisableDoubleBuffering => {
+            //                 renderer.disable_double_buffer();
+            //             }
+            //             DisplayCommand::Scroll { .. } => {
+            //                 todo!()
+            //             }
+            //         }
 
-                    if new_frame.is_none() {
-                        new_frame = renderer.render(false);
-                    }
+            //         if new_frame.is_none() {
+            //             new_frame = renderer.render(false);
+            //         }
 
-                    if let Some(frame) = new_frame {
-                        _ = data_tx.send(Mutex::new(Some(frame)));
-                    }
-                }
+            //         if let Some(frame) = new_frame {
+            //             _ = data_tx.send(Mutex::new(Some(frame)));
+            //         }
+            //     }
             })
             .abort_handle(),
             data_rx,

--- a/packages/host/src/peripherals/usb.rs
+++ b/packages/host/src/peripherals/usb.rs
@@ -1,10 +1,15 @@
 use std::{
-    io, pin::Pin, task::{Context, Poll}
+    io,
+    pin::Pin,
+    task::{Context, Poll},
 };
 
 use tokio::{
     io::{AsyncRead, AsyncWrite, ReadBuf},
-    sync::mpsc::{error::{RecvError, SendError, TrySendError}, Receiver, Sender},
+    sync::mpsc::{
+        error::{SendError, TrySendError},
+        Receiver, Sender,
+    },
 };
 use vex_v5_qemu_protocol::KernelBoundPacket;
 

--- a/packages/kernel/Cargo.toml
+++ b/packages/kernel/Cargo.toml
@@ -17,11 +17,12 @@ snafu = { version = "0.8.4", default-features = false, features = [
     "unstable-core-error",
     "rust_1_61",
 ] }
+ringbuffer = "0.16.0"
 vex-sdk = "0.19.0"
 critical-section = { version = "1.1.2", features = ["restore-state-bool"] }
-printf-compat = { version = "0.1.1", default-features = false }
 log = "0.4.22"
 embedded-io = "0.6.1"
+embedded-io-extras = { version = "0.0.2", default-features = false, features = ["alloc"] }
 bincode = { version = "2.0.0-rc.3", default-features = false, features = [
     "derive",
 ] }

--- a/packages/kernel/src/hardware/timers/private.rs
+++ b/packages/kernel/src/hardware/timers/private.rs
@@ -113,7 +113,7 @@ impl PrivateTimer {
         unsafe { XScuTimer_IsExpired(&self.instance) }
     }
 
-    pub fn raw_mut(&mut self) -> &mut XScuTimer {
+    pub const fn raw_mut(&mut self) -> &mut XScuTimer {
         &mut self.instance
     }
 }

--- a/packages/kernel/src/hardware/timers/watchdog.rs
+++ b/packages/kernel/src/hardware/timers/watchdog.rs
@@ -140,7 +140,7 @@ impl WatchdogTimer {
         unsafe { XScuWdt_IsWdtExpired(&self.instance) }
     }
 
-    pub fn raw_mut(&mut self) -> &mut XScuWdt {
+    pub const fn raw_mut(&mut self) -> &mut XScuWdt {
         &mut self.instance
     }
 }

--- a/packages/kernel/src/hardware/uart.rs
+++ b/packages/kernel/src/hardware/uart.rs
@@ -75,7 +75,7 @@ impl UartDriver {
         UartDriverError::try_from_xst_status(status)
     }
 
-    pub fn raw_mut(&mut self) -> &mut XUartPs {
+    pub const fn raw_mut(&mut self) -> &mut XUartPs {
         &mut self.instance
     }
 

--- a/packages/kernel/src/main.rs
+++ b/packages/kernel/src/main.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
-#![feature(c_variadic, naked_functions)]
+#![feature(c_variadic)]
+#![allow(static_mut_refs)]
 
 extern crate alloc;
 
@@ -15,14 +16,12 @@ pub mod sync;
 pub mod vectors;
 pub mod xil;
 
-use alloc::format;
-use core::{num::NonZeroU32, sync::atomic::Ordering};
 use crate::protocol::exit;
 use log::LevelFilter;
 use logger::KernelLogger;
 use peripherals::{GIC, PRIVATE_TIMER, UART1, WATCHDOG_TIMER};
-use sdk::{vexSystemTimeGet, vexSystemLinkAddrGet};
-use vex_v5_qemu_protocol::{code_signature::CodeSignature, HostBoundPacket, KernelBoundPacket};
+use sdk::vexSystemLinkAddrGet;
+use vex_v5_qemu_protocol::{code_signature::CodeSignature, HostBoundPacket};
 
 extern "C" {
     /// Entrypoint of the user program. (located at 0x03800020)

--- a/packages/kernel/src/sdk/device.rs
+++ b/packages/kernel/src/sdk/device.rs
@@ -3,7 +3,7 @@
 use core::ffi::{c_double, c_int};
 
 use vex_sdk::*;
-use vex_v5_qemu_protocol::{KernelBoundPacket, SmartPortData};
+use vex_v5_qemu_protocol::SmartPortData;
 
 use super::BATTERY;
 use crate::sync::Mutex;
@@ -88,7 +88,7 @@ impl Device for SmartPort {
         if let Some(data) = &self.data {
             match data {
                 SmartPortData::DistanceSensor(_) => V5_DeviceType::kDeviceTypeDistanceSensor,
-                _ => V5_DeviceType::kDeviceTypeNoSensor,
+                // _ => V5_DeviceType::kDeviceTypeNoSensor,
             }
         } else {
             V5_DeviceType::kDeviceTypeNoSensor
@@ -137,8 +137,11 @@ pub extern "C" fn vexDeviceFlagsGetByIndex(index: u32) -> u32 {
     Default::default()
 }
 pub extern "C" fn vexDeviceGetStatus(devices: *mut V5_DeviceType) -> i32 {
-    Default::default()
+    -1
 }
+/// # Safety
+///
+/// - `device` must be a valid pointer to a device handle
 pub unsafe extern "C" fn vexDeviceGetTimestamp(device: V5_DeviceT) -> u32 {
     let port_index = unsafe { *device }.zero_indexed_port;
 

--- a/packages/kernel/src/sdk/display.rs
+++ b/packages/kernel/src/sdk/display.rs
@@ -10,7 +10,7 @@ use core::{
 use vex_sdk::*;
 use vex_v5_qemu_protocol::{
     display::{
-        Color, DisplayRenderMode, DrawCommand, ScrollLocation, Shape, TextLocation, TextSize,
+        Color, DrawCommand, ScrollLocation, Shape, TextLocation, TextSize,
     },
     geometry::{Point2, Rect},
     DisplayCommand, HostBoundPacket,

--- a/packages/kernel/src/sdk/distance.rs
+++ b/packages/kernel/src/sdk/distance.rs
@@ -7,6 +7,9 @@ use vex_v5_qemu_protocol::SmartPortData;
 
 use super::SMARTPORTS;
 
+/// # Safety
+///
+/// - `device` must be a valid, non-null pointer to a device handle
 pub unsafe extern "C" fn vexDeviceDistanceDistanceGet(device: V5_DeviceT) -> u32 {
     if let Some(port) = SMARTPORTS.get(unsafe { *device }.zero_indexed_port as usize) {
         if let Some(SmartPortData::DistanceSensor(data)) = &port.lock().data {
@@ -20,6 +23,10 @@ pub unsafe extern "C" fn vexDeviceDistanceDistanceGet(device: V5_DeviceT) -> u32
 
     0
 }
+
+/// # Safety
+///
+/// - `device` must be a valid, non-null pointer to a device handle
 pub unsafe extern "C" fn vexDeviceDistanceConfidenceGet(device: V5_DeviceT) -> u32 {
     if let Some(port) = SMARTPORTS.get(unsafe { *device }.zero_indexed_port as usize) {
         if let Some(SmartPortData::DistanceSensor(data)) = &port.lock().data {
@@ -31,6 +38,10 @@ pub unsafe extern "C" fn vexDeviceDistanceConfidenceGet(device: V5_DeviceT) -> u
 
     0
 }
+
+/// # Safety
+///
+/// - `device` must be a valid, non-null pointer to a device handle
 pub unsafe extern "C" fn vexDeviceDistanceStatusGet(device: V5_DeviceT) -> u32 {
     if let Some(port) = SMARTPORTS.get(unsafe { *device }.zero_indexed_port as usize) {
         if let Some(SmartPortData::DistanceSensor(data)) = &port.lock().data {
@@ -40,20 +51,27 @@ pub unsafe extern "C" fn vexDeviceDistanceStatusGet(device: V5_DeviceT) -> u32 {
 
     0
 }
+
+/// # Safety
+///
+/// - `device` must be a valid, non-null pointer to a device handle
 pub unsafe extern "C" fn vexDeviceDistanceObjectSizeGet(device: V5_DeviceT) -> i32 {
     if let Some(port) = SMARTPORTS.get(unsafe { *device }.zero_indexed_port as usize) {
         if let Some(SmartPortData::DistanceSensor(data)) = &port.lock().data {
             return if let Some(object) = &data.object {
                 object.relative_size as _
             } else {
-                0
+                -1
             }
         }
     }
 
-    0 // TODO: test if a -1 return is actually feasable here
+    -1
 }
 
+/// # Safety
+///
+/// - `device` must be a valid, non-null pointer to a device handle
 pub unsafe extern "C" fn vexDeviceDistanceObjectVelocityGet(device: V5_DeviceT) -> c_double {
     if let Some(port) = SMARTPORTS.get(unsafe { *device }.zero_indexed_port as usize) {
         if let Some(SmartPortData::DistanceSensor(data)) = &port.lock().data {

--- a/packages/kernel/src/sdk/mod.rs
+++ b/packages/kernel/src/sdk/mod.rs
@@ -64,6 +64,8 @@ pub use task::*;
 pub use touch::*;
 pub use vision::*;
 
+use crate::vexStartup;
+
 const SYSTEM_VERSION: u32 = u32::from_be_bytes([1, 1, 4, 19]);
 const STDLIB_VERSION: u32 = 0; // only relevant for vexcode
 
@@ -81,6 +83,8 @@ pub static mut JUMP_TABLE: [*const (); 0x1000] = {
     let mut table = [unshimmed_syscall as _; 0x1000];
 
     jump_table!(table, {
+        0x0 => vexStartup,
+
         // Rotation Sensor
         0x488 => vexDeviceAbsEncReset,
         0x48c => vexDeviceAbsEncPositionSet,

--- a/packages/kernel/src/sdk/serial.rs
+++ b/packages/kernel/src/sdk/serial.rs
@@ -1,20 +1,69 @@
 //! USB Serial Communication
 
-use alloc::vec;
-use core::{
-    ffi::{c_char, VaList},
-    slice,
-};
+use core::ffi::{c_char, VaList};
 
+use embedded_io::{ErrorKind, ErrorType, Write};
+use embedded_io_extras::Cursor;
+use ringbuffer::{ConstGenericRingBuffer, RingBuffer};
 use vex_v5_qemu_protocol::HostBoundPacket;
 
-use crate::protocol;
+use crate::{protocol, sync::Mutex};
+
+pub struct SerialChannel<const TX: usize, const RX: usize> {
+    pub tx: Cursor<[u8; TX]>,
+    pub rx: ConstGenericRingBuffer<u8, RX>,
+}
+
+impl<const TX: usize, const RX: usize> SerialChannel<TX, RX> {
+    const fn new() -> Self {
+        Self {
+            tx: Cursor::new([0; TX]),
+            rx: ConstGenericRingBuffer::new(),
+        }
+    }
+
+    pub fn write_free(&self) -> usize {
+        TX - self.tx.position() as usize
+    }
+
+    pub const fn read_capacity(&self) -> usize {
+        RX
+    }
+
+    pub const fn write_capacity(&self) -> usize {
+        TX
+    }
+}
+
+impl<const TX: usize, const RX: usize> ErrorType for SerialChannel<TX, RX> {
+    type Error = ErrorKind;
+}
+
+impl<const TX: usize, const RX: usize> Write for SerialChannel<TX, RX> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.tx.write(buf)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        let pos = self.tx.position() as usize;
+
+        protocol::send_packet(HostBoundPacket::UsbSerial(
+            self.tx.get_ref()[0..pos].to_vec(),
+        ))
+        .unwrap();
+
+        self.tx.set_position(0);
+
+        Ok(())
+    }
+}
+
+pub static USB1: Mutex<SerialChannel<4096, 2048>> = Mutex::new(SerialChannel::new());
 
 pub extern "C" fn vexSerialWriteChar(channel: u32, c: u8) -> i32 {
-    if protocol::send_packet(HostBoundPacket::UsbSerial(vec![c])).is_err() {
-        -1
-    } else {
-        1
+    match channel {
+        1 => USB1.lock().write(&[c]).unwrap() as _,
+        _ => 0,
     }
 }
 
@@ -22,29 +71,44 @@ pub extern "C" fn vexSerialWriteChar(channel: u32, c: u8) -> i32 {
 ///
 /// - `data` must be a valid pointer to a buffer of length `data_len`.
 pub unsafe fn vexSerialWriteBuffer(channel: u32, data: *const u8, data_len: u32) -> i32 {
-    if data_len == 0 {
+    if data.is_null() || data_len == 0 {
         return 0;
     }
 
-    if protocol::send_packet(HostBoundPacket::UsbSerial(
-        unsafe { slice::from_raw_parts(data, data_len as usize) }.to_vec(),
-    ))
-    .is_err()
-    {
-        -1
-    } else {
-        data_len as i32
+    match channel {
+        1 => USB1
+            .lock()
+            .write(unsafe { core::slice::from_raw_parts(data, data_len as _) })
+            .unwrap() as _,
+        _ => 0,
     }
 }
+
 pub extern "C" fn vexSerialReadChar(channel: u32) -> i32 {
-    -1
+    match channel {
+        1 => USB1.lock().rx.dequeue().map(|val| val as i32).unwrap_or(-1),
+        _ => -1,
+    }
 }
 pub extern "C" fn vexSerialPeekChar(channel: u32) -> i32 {
-    -1
+    match channel {
+        1 => USB1
+            .lock()
+            .rx
+            .peek()
+            .copied()
+            .map(|val| val as i32)
+            .unwrap_or(-1),
+        _ => -1,
+    }
 }
 pub extern "C" fn vexSerialWriteFree(channel: u32) -> i32 {
-    -1
+    match channel {
+        1 => USB1.lock().write_free() as _,
+        _ => 0,
+    }
 }
+
 pub extern "C" fn vex_vprintf(format: *const c_char, args: VaList<'_, '_>) -> i32 {
     -1
 }

--- a/packages/kernel/src/sdk/task.rs
+++ b/packages/kernel/src/sdk/task.rs
@@ -2,10 +2,11 @@
 
 use core::ffi::{c_char, c_int, c_void};
 
+use embedded_io::Write;
 use vex_v5_qemu_protocol::KernelBoundPacket;
 
 use super::{BATTERY, SMARTPORTS};
-use crate::{peripherals::UART1, protocol::recv_packet};
+use crate::{peripherals::UART1, protocol::recv_packet, sdk::USB1};
 
 /// Adds a new simple task to the task scheduler.
 pub extern "C" fn vexTaskAdd(
@@ -43,6 +44,8 @@ pub extern "C" fn vexBackgroundProcessing() {}
 /// This more importantly handles many device reads and flushes
 /// serial.
 pub extern "C" fn vexTasksRun() {
+    USB1.lock().flush().unwrap(); // flush outgoing serial
+
     while !UART1.lock().is_rx_empty() {
         if let Some(packet) = recv_packet().unwrap() {
             match packet {

--- a/packages/kernel/src/xil/gic.rs
+++ b/packages/kernel/src/xil/gic.rs
@@ -15,7 +15,7 @@ pub type Xil_InterruptHandler = Option<unsafe extern "C" fn(data: *mut c_void)>;
 /// The callback reference is the base address of the interrupting device
 /// for the low level driver and an instance pointer for the high level driver.
 #[repr(C)]
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy)]
 pub struct XScuGic_VectorTableEntry {
     /// Interrupt Handler
     pub handler: Xil_InterruptHandler,
@@ -27,7 +27,7 @@ pub struct XScuGic_VectorTableEntry {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy)]
 pub struct XScuGic_Config {
     pub Name: *const c_char,
     pub DistBaseAddress: u32,
@@ -36,7 +36,7 @@ pub struct XScuGic_Config {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy)]
 pub struct XScuGic {
     pub Config: *mut XScuGic_Config,
     pub IsReady: u32,

--- a/packages/kernel/src/xil/uart.rs
+++ b/packages/kernel/src/xil/uart.rs
@@ -413,7 +413,7 @@ pub type XUartPs_Handler = extern "C" fn(CallBackRef: *mut c_void, Event: u32, E
 /// structure is passed around by functions to refer to a specific driver
 /// instance.
 #[repr(C)]
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy)]
 pub struct XUartPs {
     /// Configuration data structure
     pub Config: XUartPs_Config,

--- a/packages/protocol/src/lib.rs
+++ b/packages/protocol/src/lib.rs
@@ -9,7 +9,7 @@ use bincode::{Decode, Encode};
 use code_signature::CodeSignature;
 use controller::{ControllerData, ControllerId};
 use core::{option::Option, num::NonZeroU32};
-use display::{Color, DisplayRenderMode, DrawCommand, ScrollLocation};
+use display::{Color, DrawCommand, ScrollLocation};
 use distance_sensor::DistanceSensorData;
 use geometry::Rect;
 #[cfg(feature = "serde")]
@@ -31,7 +31,6 @@ pub enum HostBoundPacket {
     KernelSerial(Vec<u8>),
     CodeSignature(CodeSignature),
     ExitRequest(i32),
-    LinkAddressRequest,
     DisplayCommand { command: DisplayCommand },
     SmartPortCommand { port: u8, command: SmartPortCommand },
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2024-06-20"
+channel = "nightly-2025-02-18"
 components = ["rust-src"]
 targets = ["armv7a-none-eabi"]


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?
This is a big unorganized mess of changes to get things working again. Roughly:
- Properly implements serial buffering on the USB1 stream. Uses a cursor for outgoing writes and an FIFO ringbuffer for incoming reads. This fixes `println!()` on vexide. stdin is still not implemented in the host crate, though.
	- Since we don't have schedulers or simpletasks implemented yet, USB will be flushed on every call to `vexTasksRun` rather than every millisecond, but that's fine enough for now.
- Updates the CLI to not have subcommands. Instead you pass `--program=<file> --link=<file> --load-addr=<addr> --link-addr=<addr>`.
- Comments all of the host-side display driver. It needs to be rewritten and `fimg`/`atools` is kind of a dumpster fire. Might look into using vello instead here.
- Uses the debug build of the kernel ONLY if the client is built with `cfg(debug_assertions)`.