### PR TITLE
refactor: expand mmu config

### DIFF
--- a/packages/kernel/src/hardware/mmu.rs
+++ b/packages/kernel/src/hardware/mmu.rs
@@ -1,51 +1,80 @@
-use core::arch::asm;
+use core::{arch::asm, ops::Range};
 
-use cortex_ar::mmu::{
-    AccessPermissions, L1Section, MemoryRegionAttributes, SectionAttributes,
-};
+use cortex_ar::mmu::{AccessPermissions, L1Section, MemoryRegionAttributes, SectionAttributes};
 
 #[link_section = ".mmu_pages"]
 #[no_mangle]
 static MMU_PAGES: [u32; 0x1000] = {
     let mut table = [0u32; 0x1000];
-    let mut i = 0;
 
-    while i < 16 {
-        let section = L1Section::new(
-            (i as u32) << 20,
-            SectionAttributes {
-                memory_attrs: MemoryRegionAttributes::OuterAndInnerWriteBackNoWriteAlloc.as_raw(),
-                execute_never: false,
-                domain: 0,
-                access: AccessPermissions::ReadOnly,
-                non_global: false,
-                p_bit: false,
-                shareable: false,
-            },
-        );
-
-        let value = section.raw_value();
-        table[i] = value;
-        i += 1;
+    const fn configure(table: &mut [u32; 4096], range: Range<usize>, attrs: SectionAttributes) {
+        let mut i = range.start;
+        while i < range.end {
+            table[i] = L1Section::new((i as u32) << 20, attrs).raw_value();
+            i += 1;
+        }
     }
 
-    while i < 4096 {
-        let section = L1Section::new(
-            (i as u32) << 20,
-            SectionAttributes {
-                memory_attrs: MemoryRegionAttributes::OuterAndInnerWriteBackNoWriteAlloc.as_raw(),
-                execute_never: false,
-                domain: 0,
-                access: AccessPermissions::FullAccess,
-                non_global: false,
-                p_bit: false,
-                shareable: false,
-            },
-        );
+    // 0x0000_0000 - 0x00FF_FFFF: DDR (kernel, read only)
+    configure(
+        &mut table,
+        0x000..0x010,
+        SectionAttributes {
+            memory_attrs: MemoryRegionAttributes::OuterAndInnerWriteBackNoWriteAlloc.as_raw(),
+            execute_never: false,
+            domain: 0,
+            access: AccessPermissions::ReadOnly,
+            non_global: false,
+            p_bit: false,
+            shareable: false,
+        },
+    );
 
-        table[i] = section.raw_value();
-        i += 1;
-    }
+    // 0x0100_0000 - 0x3FFF_FFFF: DDR (read/write)
+    configure(
+        &mut table,
+        0x010..0x400,
+        SectionAttributes {
+            memory_attrs: MemoryRegionAttributes::OuterAndInnerWriteBackNoWriteAlloc.as_raw(),
+            execute_never: false,
+            domain: 0,
+            access: AccessPermissions::FullAccess,
+            non_global: false,
+            p_bit: false,
+            shareable: false,
+        },
+    );
+
+    // 0x4000_0000 - 0xFDFF_FFFF: Device memory (also some reserved memory)
+    configure(
+        &mut table,
+        0x400..0xFE0,
+        SectionAttributes {
+            memory_attrs: MemoryRegionAttributes::ShareableDevice.as_raw(),
+            execute_never: true,
+            domain: 0,
+            access: AccessPermissions::FullAccess,
+            non_global: false,
+            p_bit: false,
+            shareable: true,
+        },
+    );
+
+    // 0xFFF0_0000 - 0xFFFF_FFFF: OCM high (read/write)
+    // (it actually starts at 0xFFFC_0000 but we don't have that level of precision)
+    configure(
+        &mut table,
+        0xFFF..0x1000,
+        SectionAttributes {
+            memory_attrs: MemoryRegionAttributes::OuterAndInnerWriteBackNoWriteAlloc.as_raw(),
+            execute_never: false,
+            domain: 0,
+            access: AccessPermissions::FullAccess,
+            non_global: false,
+            p_bit: false,
+            shareable: false,
+        },
+    );
 
     table
 };


### PR DESCRIPTION
## Describe the changes this PR makes. Why should it be merged?

Configures devices to be non-cacheable and volatile.

## Additional Context
<!--
Move all applicable items out of the comment:
- I have tested these changes on a VEX V5 brain.
- I have tested these changes in a simulator.
- These are breaking changes (semver: major).
- These are *only* non-code changes (e.g. documentation, README.md).
- These changes update the crate's interface (e.g. functions/modules added or changed).
-->
